### PR TITLE
Add a check before getting the framepayload

### DIFF
--- a/gateway/sensor.go
+++ b/gateway/sensor.go
@@ -210,6 +210,7 @@ func (g *Gateway) handlePacket(ctx context.Context, payload []byte) {
 					return
 				}
 				g.logger.Errorf("error parsing uplink message: %s", err)
+				return
 			}
 			g.updateReadings(name, readings)
 		default:

--- a/gateway/uplink.go
+++ b/gateway/uplink.go
@@ -49,7 +49,7 @@ func (g *Gateway) parseDataUplink(ctx context.Context, phyPayload []byte) (strin
 
 	// Ensure there is a frame payload in the packet.
 	if int(8+foptsLength+1) >= (len(phyPayload) - 4) {
-		return "", map[string]interface{}{}, errors.New("device sent packet with no data")
+		return "", map[string]interface{}{}, fmt.Errorf("device %s sent packet with no data", device.NodeName)
 	}
 
 	// framepayload is the device readings.

--- a/gateway/uplink.go
+++ b/gateway/uplink.go
@@ -47,7 +47,12 @@ func (g *Gateway) parseDataUplink(ctx context.Context, phyPayload []byte) (strin
 	// frame port specifies application port - 0 is for MAC commands 1-255 for device messages.
 	fPort := phyPayload[8+foptsLength]
 
-	// device data in the message.
+	// Ensure there is a frame payload in the packet.
+	if int(8+foptsLength+1) >= (len(phyPayload) - 4) {
+		return "", map[string]interface{}{}, errors.New("device sent packet with no data")
+	}
+
+	// framepayload is the device readings.
 	framePayload := phyPayload[8+foptsLength+1 : len(phyPayload)-4]
 
 	dAddr := types.MustDevAddr(devAddrBE)

--- a/meta.json
+++ b/meta.json
@@ -1,0 +1,18 @@
+{
+    "$schema": "https://dl.viam.dev/module.schema.json",
+    "module_id": "viam:lorawan",
+    "visibility": "private",
+    "url": "https://github.com/oliviamiller/lorawan",
+    "description": "A module to collect data from LoRaWAN sensors",
+    "models": [
+        {
+            "api": "rdk:component:sensor",
+            "model": "viam:lorawan:sx1302-gateway"
+         },
+         {
+            "api": "rdk:component:sensor",
+            "model": "viam:lorawan:node"
+         }
+    ],
+    "entrypoint": "mymod"
+    }


### PR DESCRIPTION
Ran into a panic when one of the devices sent a packet with no frame payload,  the framePayload will index phyPayload[9:8] and panic. Adding a check to just error and prevent the panic. 

Also adding meta.json