### PR TITLE
RSDK-9352 Improve error handling of C code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@ CGO_BUILD_LDFLAGS := -L$(shell pwd)/$(BUILD_DIR)/libloragw -L$(shell pwd)/$(BUIL
 TOOL_BIN = bin/gotools/$(shell uname -s)-$(shell uname -m)
 UNAME_S ?= $(shell uname -s)
 
+# flag for testing
+CGO_CFLAGS := -DTESTING
+
 lorawan: sx1302
 	rm -f lorawan
 	CGO_LDFLAGS="$$CGO_LDFLAGS $(CGO_BUILD_LDFLAGS)" go build $(GO_BUILD_LDFLAGS) -o $@ main.go
@@ -14,8 +17,7 @@ module.tar.gz: lorawan first_run.sh meta.json
 
 test: lorawan
 	sudo apt install libnlopt-dev
-	CGO_LDFLAGS="$$CGO_LDFLAGS $(CGO_BUILD_LDFLAGS)" go test -race -v ./...
-
+	CGO_LDFLAGS="$$CGO_LDFLAGS $(CGO_BUILD_LDFLAGS)" CGO_CFLAGS="$(CGO_CFLAGS)" go test -race -v ./...
 
 sx1302: submodule
 	cd sx1302/libtools && make

--- a/gateway/gateway.c
+++ b/gateway/gateway.c
@@ -28,7 +28,6 @@ const int32_t rfChains [9] = {0, 0, 0, 0, 1, 1, 1};
 
 
 int setUpGateway(int bus) {
-
     // the board config defines parameters for the entire gateway HAT.
     struct lgw_conf_board_s boardconf;
 
@@ -92,11 +91,10 @@ int setUpGateway(int bus) {
             return 4;
         }
     }
-    
+
     // start the gateway.
     int res = lgw_start();
     if (res != LGW_HAL_SUCCESS) {
-        fprintf(stderr, "lgw_start failed with code: %d\n", res);
         return 5;
     }
     return 0;
@@ -116,5 +114,14 @@ int receive(struct lgw_pkt_rx_s* packet)  {
 
 int send(struct lgw_pkt_tx_s* packet) {
     return lgw_send(packet);
+}
+
+void disableBuffering() {
+    setbuf(stdout, NULL);
+}
+
+void redirectToPipe(int fd) {
+    fflush(stdout);          // Flush anything in the current stdout buffer
+    dup2(fd, STDOUT_FILENO); // Redirect stdout to the pipe's file descriptor
 }
 

--- a/gateway/gateway.c
+++ b/gateway/gateway.c
@@ -120,8 +120,16 @@ void disableBuffering() {
     setbuf(stdout, NULL);
 }
 
+
+#ifdef TESTING
+void redirectToPipe(int fd) {
+    // Mock implementation for testing - does nothing
+}
+
+#else
 void redirectToPipe(int fd) {
     fflush(stdout);          // Flush anything in the current stdout buffer
     dup2(fd, STDOUT_FILENO); // Redirect stdout to the pipe's file descriptor
 }
+#endif
 

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -234,9 +234,10 @@ func (g *gateway) captureCOutputToLogs(ctx context.Context) {
 		default:
 			if scanner.Scan() {
 				line := scanner.Text()
-				if strings.Contains(line, "ERROR") {
+				switch {
+				case strings.Contains(line, "ERROR"):
 					g.logger.Error(line)
-				} else {
+				default:
 					g.logger.Debug(line)
 				}
 			}

--- a/gateway/gateway.h
+++ b/gateway/gateway.h
@@ -8,3 +8,5 @@ int receive(struct lgw_pkt_rx_s* packet);
 int send(struct lgw_pkt_tx_s* packet);
 int stopGateway();
 int setUpGateway(int com_path);
+void disableBuffering();
+void redirectToPipe(int fd);

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -2,9 +2,7 @@ package gateway
 
 import (
 	"context"
-	"runtime"
 	"testing"
-	"time"
 
 	"gateway/node"
 
@@ -253,21 +251,16 @@ func TestStartCLogging(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	initialGoroutines := runtime.NumGoroutine()
 
 	g.startCLogging(ctx)
 	test.That(t, loggingRoutineStarted["test-gateway"], test.ShouldBeTrue)
 	test.That(t, g.workers, test.ShouldNotBeNil)
 
-	time.Sleep(100 * time.Millisecond) // Give time for goroutine to start
-	test.That(t, runtime.NumGoroutine(), test.ShouldBeGreaterThan, initialGoroutines)
-
 	// Test case 2: Ensure no new goroutine is started if the loggingRoutineStarted entry is true.
 	// reset g.workers to test for new workers
 	g.workers = nil
-	initialGoroutines = runtime.NumGoroutine()
 	g.startCLogging(ctx)
 	test.That(t, g.workers, test.ShouldBeNil)
-	time.Sleep(100 * time.Millisecond)
-	test.That(t, runtime.NumGoroutine(), test.ShouldEqual, initialGoroutines)
+	test.That(t, loggingRoutineStarted["test-gateway"], test.ShouldBeTrue)
+
 }

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -241,7 +241,6 @@ func TestStartCLogging(t *testing.T) {
 		Name: "test-gateway",
 	}
 
-	// Test case 1: Ensure logging is started if there is no entry in the loggingRoutineStarted map.
 	loggingRoutineStarted = make(map[string]bool)
 
 	g := &gateway{
@@ -252,15 +251,21 @@ func TestStartCLogging(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	// Ensure logging is started if there is no entry in the loggingRoutineStarted map.
 	g.startCLogging(ctx)
 	test.That(t, loggingRoutineStarted["test-gateway"], test.ShouldBeTrue)
 	test.That(t, g.workers, test.ShouldNotBeNil)
 
-	// Test case 2: Ensure no new goroutine is started if the loggingRoutineStarted entry is true.
-	// reset g.workers to test for new workers
+	// Test that closing the gateway removes the gateway from the loggingRoutineStarted map.
+	err := g.Close(ctx)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, len(loggingRoutineStarted), test.ShouldEqual, 0)
+
+	// Ensure no new goroutine is started if the loggingRoutineStarted entry is true.
+	// reset fields for new test case
 	g.workers = nil
+	loggingRoutineStarted["test-gateway"] = true
 	g.startCLogging(ctx)
 	test.That(t, g.workers, test.ShouldBeNil)
 	test.That(t, loggingRoutineStarted["test-gateway"], test.ShouldBeTrue)
-
 }

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -253,8 +253,9 @@ func TestStartCLogging(t *testing.T) {
 
 	// Ensure logging is started if there is no entry in the loggingRoutineStarted map.
 	g.startCLogging(ctx)
-	test.That(t, loggingRoutineStarted["test-gateway"], test.ShouldBeTrue)
 	test.That(t, g.workers, test.ShouldNotBeNil)
+	test.That(t, len(loggingRoutineStarted), test.ShouldEqual, 1)
+	test.That(t, loggingRoutineStarted["test-gateway"], test.ShouldBeTrue)
 
 	// Test that closing the gateway removes the gateway from the loggingRoutineStarted map.
 	err := g.Close(ctx)
@@ -267,5 +268,6 @@ func TestStartCLogging(t *testing.T) {
 	loggingRoutineStarted["test-gateway"] = true
 	g.startCLogging(ctx)
 	test.That(t, g.workers, test.ShouldBeNil)
+	test.That(t, len(loggingRoutineStarted), test.ShouldEqual, 1)
 	test.That(t, loggingRoutineStarted["test-gateway"], test.ShouldBeTrue)
 }

--- a/gateway/sensor.go
+++ b/gateway/sensor.go
@@ -8,10 +8,6 @@ package gateway
 #include "../sx1302/libloragw/inc/loragw_hal.h"
 #include "gateway.h"
 #include <stdlib.h>
-#include <unistd.h>
-#include <fcntl.h>
-#include <stdio.h>
-
 */
 import "C"
 
@@ -214,8 +210,7 @@ func (g *Gateway) captureOutput() error {
 
 	g.workers.Add(func(ctx context.Context) {
 		scanner := bufio.NewScanner(stdoutR)
-
-		//loop to read lines from C stdout and send them to lineChan
+		// loop to read lines from the scanner and log them
 		for {
 			select {
 			case <-ctx.Done():

--- a/gateway/sensor.go
+++ b/gateway/sensor.go
@@ -188,7 +188,7 @@ func parseErrorCode(errCode int) string {
 	case 2:
 		return "error setting the radio frequency config for radio 0"
 	case 3:
-		return "error setting the radio frrquency config for radio 1"
+		return "error setting the radio frequency config for radio 1"
 	case 4:
 		return "error setting the intermediate frequency chain config"
 	case 5:


### PR DESCRIPTION
This PR redirects C's stdout to a pipe so that we can log the C errors in real time. This will make it far easier to debug if anything goes wrong in the sx1302 code. Also added debug logs for all other prints in the C code (chose to make it debug opposed to info since its pretty verbose). 

Also adds a function to parse the error codes from the` setupGateway` function, if something errors in that function the user will see the C error log followed by the error code line from the constructor. 